### PR TITLE
Add /homes to Essentials disabled commands

### DIFF
--- a/docs/Command-Conflicts.md
+++ b/docs/Command-Conflicts.md
@@ -20,6 +20,7 @@ To do this, you must add the Essentials commands you wish to disable to the `dis
 # See https://bukkit.fandom.com/wiki/Commands.yml#aliases to map commands to other plugins.
 disabled-commands:
   - home
+  - homes
   - sethome
   - homelist
   - delhome


### PR DESCRIPTION
/homes is rendered useless along with all the other commands from essentials