### PR TITLE
refactor: Simplify teleport execution logic

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/api/BaseHuskHomesAPI.java
+++ b/common/src/main/java/net/william278/huskhomes/api/BaseHuskHomesAPI.java
@@ -730,10 +730,10 @@ public class BaseHuskHomesAPI {
     }
 
     /**
-     * Get a {@link TeleportBuilder} to construct and executeTeleport a (timed) teleport.
+     * Get a {@link TeleportBuilder} to construct and execute a (timed) teleport.
      *
      * @param teleporter The {@link OnlineUser} to teleport
-     * @return A {@link TeleportBuilder} to construct and executeTeleport a (timed) teleport
+     * @return A {@link TeleportBuilder} to construct and execute a (timed) teleport
      * @since 4.0
      */
     @NotNull
@@ -742,9 +742,9 @@ public class BaseHuskHomesAPI {
     }
 
     /**
-     * Get a {@link TeleportBuilder} to construct and executeTeleport a (timed) teleport.
+     * Get a {@link TeleportBuilder} to construct and execute a (timed) teleport.
      *
-     * @return A {@link TeleportBuilder} to construct and executeTeleport a (timed) teleport
+     * @return A {@link TeleportBuilder} to construct and execute a (timed) teleport
      * @since 4.0
      */
     @NotNull

--- a/common/src/main/java/net/william278/huskhomes/api/BaseHuskHomesAPI.java
+++ b/common/src/main/java/net/william278/huskhomes/api/BaseHuskHomesAPI.java
@@ -772,14 +772,10 @@ public class BaseHuskHomesAPI {
                         throw new IllegalStateException("Random teleport engine returned an empty position");
                     }
 
-                    final TeleportBuilder builder = Teleport.builder(plugin)
+                    Teleport.builder(plugin)
                             .teleporter(user)
-                            .target(position.get());
-                    if (timedTeleport) {
-                        builder.executeTimed();
-                    } else {
-                        builder.executeTeleport();
-                    }
+                            .target(position.get())
+                            .buildAndComplete(timedTeleport);
                 }).exceptionally(e -> {
                     throw new IllegalStateException("Random teleport engine threw an exception", e);
                 });

--- a/common/src/main/java/net/william278/huskhomes/api/BaseHuskHomesAPI.java
+++ b/common/src/main/java/net/william278/huskhomes/api/BaseHuskHomesAPI.java
@@ -29,7 +29,6 @@ import net.william278.huskhomes.position.Warp;
 import net.william278.huskhomes.random.RandomTeleportEngine;
 import net.william278.huskhomes.teleport.Teleport;
 import net.william278.huskhomes.teleport.TeleportBuilder;
-import net.william278.huskhomes.teleport.TeleportationException;
 import net.william278.huskhomes.user.OnlineUser;
 import net.william278.huskhomes.user.SavedUser;
 import net.william278.huskhomes.user.User;
@@ -731,10 +730,10 @@ public class BaseHuskHomesAPI {
     }
 
     /**
-     * Get a {@link TeleportBuilder} to construct and execute a (timed) teleport.
+     * Get a {@link TeleportBuilder} to construct and executeTeleport a (timed) teleport.
      *
      * @param teleporter The {@link OnlineUser} to teleport
-     * @return A {@link TeleportBuilder} to construct and execute a (timed) teleport
+     * @return A {@link TeleportBuilder} to construct and executeTeleport a (timed) teleport
      * @since 4.0
      */
     @NotNull
@@ -743,9 +742,9 @@ public class BaseHuskHomesAPI {
     }
 
     /**
-     * Get a {@link TeleportBuilder} to construct and execute a (timed) teleport.
+     * Get a {@link TeleportBuilder} to construct and executeTeleport a (timed) teleport.
      *
-     * @return A {@link TeleportBuilder} to construct and execute a (timed) teleport
+     * @return A {@link TeleportBuilder} to construct and executeTeleport a (timed) teleport
      * @since 4.0
      */
     @NotNull
@@ -776,14 +775,10 @@ public class BaseHuskHomesAPI {
                     final TeleportBuilder builder = Teleport.builder(plugin)
                             .teleporter(user)
                             .target(position.get());
-                    try {
-                        if (timedTeleport) {
-                            builder.toTimedTeleport().execute();
-                        } else {
-                            builder.toTeleport().execute();
-                        }
-                    } catch (TeleportationException e) {
-                        e.displayMessage(user, rtpArgs);
+                    if (timedTeleport) {
+                        builder.executeTimed();
+                    } else {
+                        builder.executeTeleport();
                     }
                 }).exceptionally(e -> {
                     throw new IllegalStateException("Random teleport engine threw an exception", e);

--- a/common/src/main/java/net/william278/huskhomes/command/BackCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/BackCommand.java
@@ -54,7 +54,7 @@ public class BackCommand extends InGameCommand {
                 .target(lastPosition.get())
                 .actions(TransactionResolver.Action.BACK_COMMAND)
                 .type(Teleport.Type.BACK)
-                .executeTimed();
+                .buildAndComplete(true);
     }
 
 }

--- a/common/src/main/java/net/william278/huskhomes/command/BackCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/BackCommand.java
@@ -22,7 +22,6 @@ package net.william278.huskhomes.command;
 import net.william278.huskhomes.HuskHomes;
 import net.william278.huskhomes.position.Position;
 import net.william278.huskhomes.teleport.Teleport;
-import net.william278.huskhomes.teleport.TeleportationException;
 import net.william278.huskhomes.user.OnlineUser;
 import net.william278.huskhomes.util.TransactionResolver;
 import org.jetbrains.annotations.NotNull;
@@ -50,17 +49,12 @@ public class BackCommand extends InGameCommand {
             return;
         }
 
-        try {
-            Teleport.builder(plugin)
-                    .teleporter(executor)
-                    .target(lastPosition.get())
-                    .actions(TransactionResolver.Action.BACK_COMMAND)
-                    .type(Teleport.Type.BACK)
-                    .toTimedTeleport()
-                    .execute();
-        } catch (TeleportationException e) {
-            e.displayMessage(executor, args);
-        }
+        Teleport.builder(plugin)
+                .teleporter(executor)
+                .target(lastPosition.get())
+                .actions(TransactionResolver.Action.BACK_COMMAND)
+                .type(Teleport.Type.BACK)
+                .executeTimed();
     }
 
 }

--- a/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
@@ -23,7 +23,6 @@ import net.william278.huskhomes.HuskHomes;
 import net.william278.huskhomes.position.World;
 import net.william278.huskhomes.teleport.Teleport;
 import net.william278.huskhomes.teleport.TeleportBuilder;
-import net.william278.huskhomes.teleport.TeleportationException;
 import net.william278.huskhomes.user.CommandUser;
 import net.william278.huskhomes.user.OnlineUser;
 import net.william278.huskhomes.util.TransactionResolver;
@@ -60,7 +59,7 @@ public class RtpCommand extends Command implements UserListTabProvider {
             return;
         }
 
-        // Validate, then execute the RTP
+        // Validate, then executeTeleport the RTP
         final OnlineUser teleporter = optionalTeleporter.get();
         this.validateRtp(teleporter, executor, args.length > 1 ? removeFirstArg(args) : args)
                 .ifPresent(world -> this.executeRtp(teleporter, executor, world, args));
@@ -149,20 +148,12 @@ public class RtpCommand extends Command implements UserListTabProvider {
                         return;
                     }
 
-                    // Build and execute the teleport
+                    // Build and executeTeleport the teleport
                     final TeleportBuilder builder = Teleport.builder(plugin)
                             .teleporter(teleporter)
                             .actions(TransactionResolver.Action.RANDOM_TELEPORT)
                             .target(position.get());
-                    try {
-                        if (executor.equals(teleporter)) {
-                            builder.toTimedTeleport().execute();
-                        } else {
-                            builder.toTeleport().execute();
-                        }
-                    } catch (TeleportationException e) {
-                        e.displayMessage(executor, args);
-                    }
+                    builder.buildAndComplete(executor.equals(teleporter), args);
                 });
     }
 

--- a/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
@@ -148,7 +148,7 @@ public class RtpCommand extends Command implements UserListTabProvider {
                         return;
                     }
 
-                    // Build and executeTeleport the teleport
+                    // Build and execute the teleport
                     final TeleportBuilder builder = Teleport.builder(plugin)
                             .teleporter(teleporter)
                             .actions(TransactionResolver.Action.RANDOM_TELEPORT)

--- a/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
@@ -59,7 +59,7 @@ public class RtpCommand extends Command implements UserListTabProvider {
             return;
         }
 
-        // Validate, then executeTeleport the RTP
+        // Validate, then execute the RTP
         final OnlineUser teleporter = optionalTeleporter.get();
         this.validateRtp(teleporter, executor, args.length > 1 ? removeFirstArg(args) : args)
                 .ifPresent(world -> this.executeRtp(teleporter, executor, world, args));

--- a/common/src/main/java/net/william278/huskhomes/command/SavedPositionCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/SavedPositionCommand.java
@@ -24,9 +24,7 @@ import net.william278.huskhomes.position.Home;
 import net.william278.huskhomes.position.SavedPosition;
 import net.william278.huskhomes.position.Warp;
 import net.william278.huskhomes.teleport.Teleport;
-import net.william278.huskhomes.teleport.TeleportBuilder;
 import net.william278.huskhomes.teleport.Teleportable;
-import net.william278.huskhomes.teleport.TeleportationException;
 import net.william278.huskhomes.user.CommandUser;
 import net.william278.huskhomes.user.OnlineUser;
 import net.william278.huskhomes.user.User;
@@ -166,19 +164,11 @@ public abstract class SavedPositionCommand<T extends SavedPosition> extends Comm
             return;
         }
 
-        final TeleportBuilder builder = Teleport.builder(plugin)
+        Teleport.builder(plugin)
                 .teleporter(teleporter)
                 .actions(actions)
-                .target(position);
-        try {
-            if (executor.equals(teleporter)) {
-                builder.toTimedTeleport().execute();
-            } else {
-                builder.toTeleport().execute();
-            }
-        } catch (TeleportationException e) {
-            e.displayMessage(executor, teleporter.getUsername());
-        }
+                .target(position)
+                .buildAndComplete(executor.equals(teleporter), teleporter.getUsername());
     }
 
     @NotNull

--- a/common/src/main/java/net/william278/huskhomes/command/SpawnCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/SpawnCommand.java
@@ -24,7 +24,6 @@ import net.william278.huskhomes.position.Position;
 import net.william278.huskhomes.teleport.Teleport;
 import net.william278.huskhomes.teleport.TeleportBuilder;
 import net.william278.huskhomes.teleport.Teleportable;
-import net.william278.huskhomes.teleport.TeleportationException;
 import net.william278.huskhomes.user.CommandUser;
 import net.william278.huskhomes.util.TransactionResolver;
 import org.jetbrains.annotations.NotNull;
@@ -71,14 +70,10 @@ public class SpawnCommand extends Command {
                 .teleporter(teleporter)
                 .actions(TransactionResolver.Action.SPAWN_TELEPORT)
                 .target(spawn);
-        try {
-            if (teleporter.equals(executor)) {
-                builder.toTimedTeleport().execute();
-            } else {
-                builder.toTeleport().execute();
-            }
-        } catch (TeleportationException e) {
-            e.displayMessage(executor, args);
+        if (teleporter.equals(executor)) {
+            builder.executeTimed();
+        } else {
+            builder.executeTeleport();
         }
     }
 

--- a/common/src/main/java/net/william278/huskhomes/command/SpawnCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/SpawnCommand.java
@@ -22,7 +22,6 @@ package net.william278.huskhomes.command;
 import net.william278.huskhomes.HuskHomes;
 import net.william278.huskhomes.position.Position;
 import net.william278.huskhomes.teleport.Teleport;
-import net.william278.huskhomes.teleport.TeleportBuilder;
 import net.william278.huskhomes.teleport.Teleportable;
 import net.william278.huskhomes.user.CommandUser;
 import net.william278.huskhomes.util.TransactionResolver;
@@ -66,15 +65,11 @@ public class SpawnCommand extends Command {
             return;
         }
 
-        final TeleportBuilder builder = Teleport.builder(plugin)
+        Teleport.builder(plugin)
                 .teleporter(teleporter)
                 .actions(TransactionResolver.Action.SPAWN_TELEPORT)
-                .target(spawn);
-        if (teleporter.equals(executor)) {
-            builder.executeTimed();
-        } else {
-            builder.executeTeleport();
-        }
+                .target(spawn)
+                .buildAndComplete(teleporter.equals(executor), args);
     }
 
 }

--- a/common/src/main/java/net/william278/huskhomes/command/TpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/TpCommand.java
@@ -84,7 +84,7 @@ public class TpCommand extends Command implements TabProvider {
     // Execute a teleport
     private void execute(@NotNull CommandUser executor, @NotNull Teleportable teleportable, @NotNull Target target,
                          @NotNull String[] args) {
-        // Build and executeTeleport the teleport
+        // Build and execute the teleport
         final TeleportBuilder builder = Teleport.builder(plugin)
                 .teleporter(teleportable)
                 .target(target);

--- a/common/src/main/java/net/william278/huskhomes/command/TpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/TpCommand.java
@@ -84,19 +84,14 @@ public class TpCommand extends Command implements TabProvider {
     // Execute a teleport
     private void execute(@NotNull CommandUser executor, @NotNull Teleportable teleportable, @NotNull Target target,
                          @NotNull String[] args) {
-        // Build and execute the teleport
+        // Build and executeTeleport the teleport
         final TeleportBuilder builder = Teleport.builder(plugin)
                 .teleporter(teleportable)
                 .target(target);
-        try {
-            if (executor instanceof OnlineUser user) {
-                builder.executor(user);
-            }
-            builder.toTeleport().execute();
-        } catch (TeleportationException e) {
-            e.displayMessage(executor, args);
-            return;
+        if (executor instanceof OnlineUser user) {
+            builder.executor(user);
         }
+        builder.executeTeleport(args);
 
         // Display a teleport completion message
         final String teleporterName = teleportable instanceof OnlineUser user

--- a/common/src/main/java/net/william278/huskhomes/command/TpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/TpCommand.java
@@ -91,7 +91,7 @@ public class TpCommand extends Command implements TabProvider {
         if (executor instanceof OnlineUser user) {
             builder.executor(user);
         }
-        builder.executeTeleport(args);
+        builder.buildAndComplete(false, args);
 
         // Display a teleport completion message
         final String teleporterName = teleportable instanceof OnlineUser user

--- a/common/src/main/java/net/william278/huskhomes/command/TpHereCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/TpHereCommand.java
@@ -21,7 +21,6 @@ package net.william278.huskhomes.command;
 
 import net.william278.huskhomes.HuskHomes;
 import net.william278.huskhomes.teleport.Teleport;
-import net.william278.huskhomes.teleport.TeleportationException;
 import net.william278.huskhomes.user.OnlineUser;
 import org.jetbrains.annotations.NotNull;
 
@@ -44,18 +43,15 @@ public class TpHereCommand extends InGameCommand implements UserListTabProvider 
             return;
         }
 
-        try {
-            Teleport.builder(plugin)
-                    .executor(executor)
-                    .teleporter(optionalTarget.get())
-                    .target(executor.getPosition())
-                    .toTeleport().execute();
+        // Teleport the user
+        final String target = optionalTarget.get();
+        Teleport.builder(plugin)
+                .executor(executor)
+                .teleporter(target)
+                .target(executor.getPosition())
+                .buildAndComplete(false, target);
 
-            plugin.getLocales().getLocale("teleporting_other_complete",
-                    optionalTarget.get(), executor.getUsername());
-        } catch (TeleportationException e) {
-            e.displayMessage(executor, args);
-        }
+        plugin.getLocales().getLocale("teleporting_other_complete", target, executor.getUsername());
     }
 
 }

--- a/common/src/main/java/net/william278/huskhomes/command/TpOfflineCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/TpOfflineCommand.java
@@ -22,7 +22,6 @@ package net.william278.huskhomes.command;
 import net.william278.huskhomes.HuskHomes;
 import net.william278.huskhomes.position.Position;
 import net.william278.huskhomes.teleport.Teleport;
-import net.william278.huskhomes.teleport.TeleportationException;
 import net.william278.huskhomes.user.OnlineUser;
 import net.william278.huskhomes.user.SavedUser;
 import net.william278.huskhomes.user.User;
@@ -69,14 +68,10 @@ public class TpOfflineCommand extends InGameCommand implements UserListTabProvid
 
         plugin.getLocales().getLocale("teleporting_offline_player", target.getUsername())
                 .ifPresent(user::sendMessage);
-        try {
-            Teleport.builder(plugin)
-                    .teleporter(user)
-                    .target(position.get())
-                    .toTeleport().execute();
-        } catch (TeleportationException e) {
-            e.displayMessage(user, args);
-        }
+        Teleport.builder(plugin)
+                .teleporter(user)
+                .target(position.get())
+                .buildAndComplete(false, args);
     }
 
 }

--- a/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
+++ b/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
@@ -59,6 +59,7 @@ public class EventListener {
         plugin.runAsync(() -> {
             // Ensure the user is in the database
             plugin.getDatabase().ensureUser(onlineUser);
+            plugin.getCurrentlyOnWarmup().remove(onlineUser.getUuid());
 
             // Handle cross-server checks
             if (plugin.getSettings().getCrossServer().isEnabled()) {
@@ -161,17 +162,11 @@ public class EventListener {
             plugin.getSpawn().ifPresent(spawn -> {
                 if (plugin.getSettings().getCrossServer().isEnabled()
                         && !spawn.getServer().equals(plugin.getServerName())) {
-                    plugin.runSyncDelayed(() -> {
-                        try {
-                            Teleport.builder(plugin)
-                                    .teleporter(teleporter)
-                                    .target(spawn)
-                                    .updateLastPosition(false)
-                                    .toTeleport().execute();
-                        } catch (TeleportationException e) {
-                            e.displayMessage(teleporter);
-                        }
-                    }, 40L);
+                    plugin.runSyncDelayed(() -> Teleport.builder(plugin)
+                            .teleporter(teleporter)
+                            .target(spawn)
+                            .updateLastPosition(false)
+                            .buildAndComplete(false), 40L);
                 } else {
                     try {
                         teleporter.teleportLocally(spawn, plugin.getSettings().getGeneral().isTeleportAsync());

--- a/common/src/main/java/net/william278/huskhomes/manager/RequestsManager.java
+++ b/common/src/main/java/net/william278/huskhomes/manager/RequestsManager.java
@@ -26,7 +26,6 @@ import net.william278.huskhomes.network.Payload;
 import net.william278.huskhomes.teleport.Teleport;
 import net.william278.huskhomes.teleport.TeleportBuilder;
 import net.william278.huskhomes.teleport.TeleportRequest;
-import net.william278.huskhomes.teleport.TeleportationException;
 import net.william278.huskhomes.user.OnlineUser;
 import net.william278.huskhomes.user.SavedUser;
 import net.william278.huskhomes.user.User;
@@ -323,12 +322,7 @@ public class RequestsManager {
                 } else {
                     builder.target(request.getRequesterName());
                 }
-
-                try {
-                    builder.toTimedTeleport().execute();
-                } catch (TeleportationException e) {
-                    e.displayMessage(recipient);
-                }
+                builder.buildAndComplete(true);
             }
         }));
     }
@@ -354,16 +348,11 @@ public class RequestsManager {
 
         // If the request is a tpa request, teleport the requester to the recipient
         if (accepted && (request.getType() == TeleportRequest.Type.TPA)) {
-            try {
-                Teleport.builder(plugin)
-                        .teleporter(requester)
-                        .target(request.getRecipientName())
-                        .actions(TransactionResolver.Action.ACCEPT_TELEPORT_REQUEST)
-                        .toTimedTeleport()
-                        .execute();
-            } catch (TeleportationException e) {
-                e.displayMessage(requester);
-            }
+            Teleport.builder(plugin)
+                    .teleporter(requester)
+                    .target(request.getRecipientName())
+                    .actions(TransactionResolver.Action.ACCEPT_TELEPORT_REQUEST)
+                    .buildAndComplete(true);
         }
     }
 

--- a/common/src/main/java/net/william278/huskhomes/network/Broker.java
+++ b/common/src/main/java/net/william278/huskhomes/network/Broker.java
@@ -24,7 +24,6 @@ import net.william278.huskhomes.HuskHomes;
 import net.william278.huskhomes.position.Home;
 import net.william278.huskhomes.position.Warp;
 import net.william278.huskhomes.teleport.Teleport;
-import net.william278.huskhomes.teleport.TeleportationException;
 import net.william278.huskhomes.user.OnlineUser;
 import org.jetbrains.annotations.NotNull;
 
@@ -58,17 +57,11 @@ public abstract class Broker {
         }
         switch (message.getType()) {
             case TELEPORT_TO_POSITION -> message.getPayload()
-                    .getPosition().ifPresent(position -> {
-                        try {
-                            Teleport.builder(plugin)
-                                    .teleporter(receiver)
-                                    .target(position)
-                                    .toTeleport()
-                                    .execute();
-                        } catch (TeleportationException e) {
-                            e.displayMessage(plugin.getConsole());
-                        }
-                    });
+                    .getPosition().ifPresent(position -> Teleport.builder(plugin)
+                            .teleporter(receiver)
+                            .target(position)
+                            .toTeleport()
+                            .complete());
             case TELEPORT_TO_NETWORKED_POSITION -> Message.builder()
                     .type(Message.Type.TELEPORT_TO_POSITION)
                     .target(message.getSender())

--- a/common/src/main/java/net/william278/huskhomes/teleport/Completable.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/Completable.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package net.william278.huskhomes.teleport;
+
+import net.william278.huskhomes.user.OnlineUser;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a Teleport that is completable
+ */
+public interface Completable {
+
+    void execute() throws TeleportationException;
+
+    @NotNull
+    OnlineUser getExecutor();
+
+    /**
+     * Complete the teleport and handle exceptions
+     *
+     * @param args Optional args to pass to the teleport exception handler
+     */
+    default void complete(@NotNull String... args) {
+        try {
+            execute();
+        } catch (TeleportationException e) {
+            e.displayMessage(getExecutor(), args);
+        }
+    }
+
+}

--- a/common/src/main/java/net/william278/huskhomes/teleport/TeleportBuilder.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/TeleportBuilder.java
@@ -71,6 +71,14 @@ public class TeleportBuilder {
         );
     }
 
+    public void buildAndComplete(boolean timed, @NotNull String... args) {
+        try {
+            (timed ? toTimedTeleport() : toTeleport()).complete(args);
+        } catch (TeleportationException e) {
+            e.displayMessage(executor);
+        }
+    }
+
     private void validateTeleport() throws TeleportationException {
         if (teleporter == null) {
             throw new TeleportationException(TeleportationException.Type.TELEPORTER_NOT_FOUND, plugin);

--- a/common/src/main/java/net/william278/huskhomes/teleport/TeleportationException.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/TeleportationException.java
@@ -19,6 +19,7 @@
 
 package net.william278.huskhomes.teleport;
 
+import lombok.Getter;
 import net.william278.huskhomes.HuskHomes;
 import net.william278.huskhomes.user.CommandUser;
 import org.jetbrains.annotations.NotNull;
@@ -26,6 +27,7 @@ import org.jetbrains.annotations.NotNull;
 public class TeleportationException extends IllegalStateException {
 
     private final HuskHomes plugin;
+    @Getter
     private final Type type;
 
     public TeleportationException(@NotNull Type cause, @NotNull HuskHomes plugin) {
@@ -58,12 +60,6 @@ public class TeleportationException extends IllegalStateException {
                 // Silent; no message
             }
         }
-    }
-
-    @NotNull
-    @SuppressWarnings("unused")
-    public Type getType() {
-        return type;
     }
 
     /**

--- a/common/src/main/java/net/william278/huskhomes/teleport/TimedTeleport.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/TimedTeleport.java
@@ -104,7 +104,13 @@ public class TimedTeleport extends Teleport implements Runnable, Completable {
         } else {
             plugin.getLocales().getLocale("teleporting_action_bar_processing")
                     .ifPresent(this::sendStatusMessage);
-            super.execute();
+
+            try {
+                super.execute();
+            } catch (TeleportationException e) {
+                e.displayMessage(executor);
+                return;
+            }
         }
 
         // Tick (decrement) the timed teleport timer and end it if done

--- a/common/src/main/java/net/william278/huskhomes/teleport/TimedTeleport.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/TimedTeleport.java
@@ -108,7 +108,9 @@ public class TimedTeleport extends Teleport implements Runnable, Completable {
             try {
                 super.execute();
             } catch (TeleportationException e) {
-                e.displayMessage(executor);
+                e.displayMessage(teleporter);
+                task.cancel();
+                plugin.getCurrentlyOnWarmup().remove(teleporter.getUuid());
                 return;
             }
         }

--- a/common/src/main/java/net/william278/huskhomes/teleport/TimedTeleport.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/TimedTeleport.java
@@ -80,7 +80,7 @@ public class TimedTeleport extends Teleport implements Runnable, Completable {
         this.process();
     }
 
-    // Execute the warmup, fire the event, then executeTeleport the teleport if warmup completes normally
+    // Execute the warmup, fire the event, then execute the teleport if warmup completes normally
     private void process() {
         plugin.fireEvent(plugin.getTeleportWarmupEvent(this, timeLeft), (event) -> {
             plugin.getCurrentlyOnWarmup().add(teleporter.getUuid());

--- a/common/src/main/java/net/william278/huskhomes/teleport/TimedTeleport.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/TimedTeleport.java
@@ -76,7 +76,7 @@ public class TimedTeleport extends Teleport implements Runnable, Completable {
             throw new TeleportationException(TeleportationException.Type.WARMUP_ALREADY_MOVING, plugin);
         }
 
-        // Process the warmup and executeTeleport the teleport
+        // Process the warmup and execute the teleport
         this.process();
     }
 

--- a/common/src/main/java/net/william278/huskhomes/teleport/TimedTeleport.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/TimedTeleport.java
@@ -36,7 +36,7 @@ import java.util.List;
  *
  * @see Teleport#builder(HuskHomes)
  */
-public class TimedTeleport extends Teleport implements Runnable {
+public class TimedTeleport extends Teleport implements Runnable, Completable {
 
     public static final String BYPASS_PERMISSION = "huskhomes.bypass_teleport_warmup";
     private final OnlineUser teleporter;
@@ -76,11 +76,11 @@ public class TimedTeleport extends Teleport implements Runnable {
             throw new TeleportationException(TeleportationException.Type.WARMUP_ALREADY_MOVING, plugin);
         }
 
-        // Process the warmup and execute the teleport
+        // Process the warmup and executeTeleport the teleport
         this.process();
     }
 
-    // Execute the warmup, fire the event, then execute the teleport if warmup completes normally
+    // Execute the warmup, fire the event, then executeTeleport the teleport if warmup completes normally
     private void process() {
         plugin.fireEvent(plugin.getTeleportWarmupEvent(this, timeLeft), (event) -> {
             plugin.getCurrentlyOnWarmup().add(teleporter.getUuid());
@@ -104,11 +104,7 @@ public class TimedTeleport extends Teleport implements Runnable {
         } else {
             plugin.getLocales().getLocale("teleporting_action_bar_processing")
                     .ifPresent(this::sendStatusMessage);
-            try {
-                super.execute();
-            } catch (TeleportationException e) {
-                e.displayMessage(teleporter);
-            }
+            super.execute();
         }
 
         // Tick (decrement) the timed teleport timer and end it if done

--- a/common/src/main/resources/locales/en-gb.yml
+++ b/common/src/main/resources/locales/en-gb.yml
@@ -126,7 +126,7 @@ locales:
   error_home_description_characters: '[Error:](#ff3300) [Home descriptions may only contain alphanumeric (A-Z, 0-9) characters, spaces, hyphens (-) and underscores (_)](#ff7e5e)'
   error_warp_description_length: '[Error:](#ff3300) [Warp descriptions must be less than 255 characters in length.](#ff7e5e)'
   error_warp_description_characters: '[Error:](#ff3300) [Warp descriptions may only contain alphanumeric (A-Z, 0-9) characters, spaces, hyphens (-) and underscores (_)](#ff7e5e)'
-  error_no_permission: '[Error:](#ff3300) [You do not have permission to executeTeleport that command.](#ff7e5e)'
+  error_no_permission: '[Error:](#ff3300) [You do not have permission to execute that command.](#ff7e5e)'
   error_invalid_syntax: '[Error:](#ff3300) [Incorrect syntax. Usage:](#ff7e5e) [%1%](#ff7e5e italic show_text=&#ff7e5e&Click to suggest suggest_command=%1%)'
   error_already_teleporting: '[Error:](#ff3300) [Please wait for the current teleport to finish!](#ff7e5e)'
   error_no_last_position: '[Error:](#ff3300) [You have no last position to return to!](#ff7e5e)'

--- a/common/src/main/resources/locales/en-gb.yml
+++ b/common/src/main/resources/locales/en-gb.yml
@@ -126,7 +126,7 @@ locales:
   error_home_description_characters: '[Error:](#ff3300) [Home descriptions may only contain alphanumeric (A-Z, 0-9) characters, spaces, hyphens (-) and underscores (_)](#ff7e5e)'
   error_warp_description_length: '[Error:](#ff3300) [Warp descriptions must be less than 255 characters in length.](#ff7e5e)'
   error_warp_description_characters: '[Error:](#ff3300) [Warp descriptions may only contain alphanumeric (A-Z, 0-9) characters, spaces, hyphens (-) and underscores (_)](#ff7e5e)'
-  error_no_permission: '[Error:](#ff3300) [You do not have permission to execute that command.](#ff7e5e)'
+  error_no_permission: '[Error:](#ff3300) [You do not have permission to executeTeleport that command.](#ff7e5e)'
   error_invalid_syntax: '[Error:](#ff3300) [Incorrect syntax. Usage:](#ff7e5e) [%1%](#ff7e5e italic show_text=&#ff7e5e&Click to suggest suggest_command=%1%)'
   error_already_teleporting: '[Error:](#ff3300) [Please wait for the current teleport to finish!](#ff7e5e)'
   error_no_last_position: '[Error:](#ff3300) [You have no last position to return to!](#ff7e5e)'

--- a/docs/API-Examples.md
+++ b/docs/API-Examples.md
@@ -148,7 +148,7 @@ public class HuskHomesAPIHook {
 </details>
 
 ## Creating Teleports
-The API provides a method for getting a `TeleportBuilder`, which can be used to build a `Teleport` (with `#toTeleport`) or `TimedTeleport` (with toTimedTeleport; a teleport that requires the user to stand still for a period of time first). Teleports can be cross-server.
+The API provides a method for getting a `TeleportBuilder`, which can be used to build a `Teleport` (with `#toTeleport`) or `TimedTeleport` (a teleport that requires the user to stand still for a period of time first). Teleports can be cross-server.
 
 <details>
 <summary>Building a teleport</summary>
@@ -171,15 +171,12 @@ public class HuskHomesAPIHook {
         );
 
         // To construct a teleport, get a TeleportBuilder with #teleportBuilder
-        try {
-            huskHomesAPI.teleportBuilder()
-                .teleporter(onlineUser) // The person being teleported
-                .target(position) // The target position
-                .toTimedTeleport()
-                .execute(); // #execute() can throw a TeleportationException
-        } catch(TeleportationException e) {
-            e.printStackTrace(); // This exception will contain the reason why the teleport failed, so you can handle it gracefully.
-        }
+        huskHomesAPI.teleportBuilder()
+            .teleporter(onlineUser) // The person being teleported
+            .target(position) // The target position
+            .buildAndComplete(false); // This builds and executes the teleport instantly.
+        
+        // The `true` flag we passed above indicates we want an instant teleport (as opposed to a timed teleport)
     }
 
 }
@@ -206,10 +203,11 @@ public class HuskHomesAPIHook {
             huskHomesAPI.teleportBuilder()
                 .teleporter(onlineUser)
                 .target(targetUsername)
-                .toTimedTeleport()
+                .toTimedTeleport() // Instead of running buildAndComplete, we can get the Teleport object itself this way.
                 .execute(); // A timed teleport will throw a TeleportationException if the player moves/takes damage during the warmup, or if the target is not found.
-        } catch(TeleportationException e) {
-            e.printStackTrace(); // Note that the TimedTeleport will catch internal exceptions when executing the resultant Teleport (e.g. if the teleport is to an illegal position).
+        } catch(TeleportationException e) { // Since this doesn't catch the TeleportException (buildAndComplete does!), we need to do this.
+            // Use TeleportException#displayMessage() to display why the teleport failed to the user.
+            e.displayMessage(onlineUser);
         }
     }
 


### PR DESCRIPTION
Stop requiring everyone to have to catch TeleportExceptions and provide a `complete()` API for doing this. Also provide utility `buildAndExecute()` `TeleportBuilder` method.