### PR TITLE
Fabric: Add Support for Impactor Economy and PlaceholderAPI

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -5,10 +5,23 @@ plugins {
 apply plugin: 'fabric-loom'
 loom.serverOnlyMinecraftJar()
 
+repositories {
+    maven {
+        url "https://maven.impactdev.net/repository/development/"
+        name "Impactor Economy"
+    }
+    maven {
+        url "https://maven.nucleoid.xyz/"
+        name "placeholderapi"
+    }
+}
+
 dependencies {
     minecraft "com.mojang:minecraft:${fabric_minecraft_version}"
     mappings "net.fabricmc:yarn:${fabric_yarn_mappings}:v2"
     modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
+    modImplementation("net.impactdev.impactor.api:economy:${impactor_api_version}")
+    modImplementation include("eu.pb4:placeholder-api:${placeholder_api_version}")
 
     // Fabric API modules
     Set<String> fabricApiModules = [

--- a/fabric/src/main/java/net/william278/huskhomes/FabricHuskHomes.java
+++ b/fabric/src/main/java/net/william278/huskhomes/FabricHuskHomes.java
@@ -51,7 +51,9 @@ import net.william278.huskhomes.database.H2Database;
 import net.william278.huskhomes.database.MySqlDatabase;
 import net.william278.huskhomes.database.SqLiteDatabase;
 import net.william278.huskhomes.event.FabricEventDispatcher;
+import net.william278.huskhomes.hook.FabricImpactorEconomyHook;
 import net.william278.huskhomes.hook.Hook;
+import net.william278.huskhomes.hook.PlaceHolderAPIHook;
 import net.william278.huskhomes.listener.EventListener;
 import net.william278.huskhomes.listener.FabricEventListener;
 import net.william278.huskhomes.manager.Manager;
@@ -189,6 +191,20 @@ public class FabricHuskHomes implements DedicatedServerModInitializer, HuskHomes
         initialize("events", (plugin) -> this.eventListener = new FabricEventListener(this));
 
         this.checkForUpdates();
+    }
+
+    @Override
+    public void registerHooks() {
+        HuskHomes.super.registerHooks();
+
+        // Register the impactor economy service if it is available
+        if (getSettings().getEconomy().isEnabled() && isDependencyLoaded("impactor")) {
+            getHooks().add(new FabricImpactorEconomyHook(this));
+        }
+
+        if (isDependencyLoaded("placeholder-api")) {
+            getHooks().add(new PlaceHolderAPIHook(this));
+        }
     }
 
     private void onDisable() {

--- a/fabric/src/main/java/net/william278/huskhomes/hook/FabricImpactorEconomyHook.java
+++ b/fabric/src/main/java/net/william278/huskhomes/hook/FabricImpactorEconomyHook.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package net.william278.huskhomes.hook;
+
+import net.impactdev.impactor.api.economy.EconomyService;
+import net.impactdev.impactor.api.economy.accounts.Account;
+import net.impactdev.impactor.api.economy.currency.Currency;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import net.william278.huskhomes.HuskHomes;
+import net.william278.huskhomes.user.OnlineUser;
+import org.jetbrains.annotations.NotNull;
+
+import java.math.BigDecimal;
+import java.util.concurrent.ExecutionException;
+
+public class FabricImpactorEconomyHook extends EconomyHook {
+    private EconomyService economyService;
+    private Currency currency;
+
+    public FabricImpactorEconomyHook(@NotNull HuskHomes plugin) {
+        super(plugin, "Fabric Impactor Economy");
+    }
+
+    @Override
+    public double getPlayerBalance(@NotNull OnlineUser player) {
+        try {
+            //If no account is found, a new account will be generated instead.
+            final Account account = economyService.account(player.getUuid()).get();
+            return account.balance().doubleValue();
+        } catch (ExecutionException | InterruptedException e) {
+            return BigDecimal.ZERO.doubleValue();
+        }
+    }
+
+    @Override
+    public void changePlayerBalance(@NotNull OnlineUser player, double amount) {
+        if (amount == 0d) {
+            return;
+        }
+        final Account account;
+        try {
+            account = economyService.account(player.getUuid()).get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+        final double currentBalance = account.balance().doubleValue();
+        final double amountToChange = Math.abs(currentBalance - Math.max(0d, currentBalance + amount));
+        if (amount < 0d) {
+            account.withdrawAsync(
+                    BigDecimal.valueOf(amountToChange)
+            );
+        } else {
+            account.depositAsync(
+                    BigDecimal.valueOf(amountToChange)
+            );
+        }
+    }
+
+    @Override
+    public String formatCurrency(double amount) {
+        return PlainTextComponentSerializer.plainText().serialize(currency.format(BigDecimal.valueOf(amount)));
+    }
+
+    @Override
+    public void initialize() {
+        this.economyService = EconomyService.instance();
+        if (this.economyService == null) {
+            throw new IllegalStateException("Impactor API is not available, No economy service has been registered!");
+        }
+        this.currency = this.economyService.currencies().primary();
+    }
+}

--- a/fabric/src/main/java/net/william278/huskhomes/hook/PlaceHolderAPIHook.java
+++ b/fabric/src/main/java/net/william278/huskhomes/hook/PlaceHolderAPIHook.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package net.william278.huskhomes.hook;
+
+import eu.pb4.placeholders.api.PlaceholderResult;
+import eu.pb4.placeholders.api.Placeholders;
+import net.minecraft.util.Identifier;
+import net.william278.huskhomes.FabricHuskHomes;
+import net.william278.huskhomes.user.FabricUser;
+import net.william278.huskhomes.user.OnlineUser;
+import net.william278.huskhomes.user.SavedUser;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class PlaceHolderAPIHook extends Hook {
+
+    public PlaceHolderAPIHook(@NotNull FabricHuskHomes plugin) {
+        super(plugin, "Fabric PlaceholderAPI");
+    }
+
+    private Identifier createIdentifier(String placeholderName) {
+        return new Identifier("huskhomes", placeholderName);
+    }
+
+    @Override
+    public void initialize() {
+        Placeholders.register(createIdentifier("player"), (ctx, arg) -> {
+            if (!ctx.hasPlayer()) {
+                return PlaceholderResult.invalid("No player!");
+            }
+
+
+            if (arg == null) {
+                return PlaceholderResult.invalid("No argument for player!");
+            }
+
+            assert ctx.player() != null;
+            final OnlineUser player = FabricUser.adapt(ctx.player(), (FabricHuskHomes) plugin);
+
+            final String response = switch (arg) {
+                case "homes_count" -> String.valueOf(plugin.getManager().homes()
+                        .getUserHomes()
+                        .getOrDefault(player.getUsername(), List.of()).size());
+                case "max_homes" -> String.valueOf(plugin.getManager().homes().getMaxHomes(player));
+                case "max_public_homes" -> String.valueOf(plugin.getManager().homes().getMaxPublicHomes(player));
+                case "free_home_slots" -> String.valueOf(plugin.getManager().homes().getFreeHomes(player));
+                case "home_slots" -> String.valueOf(plugin.getSavedUser(player)
+                        .map(SavedUser::getHomeSlots).orElse(0));
+                case "homes_list" -> String.join(", ", plugin.getManager().homes()
+                        .getUserHomes()
+                        .getOrDefault(player.getUsername(), List.of()));
+                case "public_homes_count" -> String.valueOf(plugin.getManager().homes()
+                        .getPublicHomes()
+                        .getOrDefault(player.getUsername(), List.of()).size());
+                case "public_homes_list" -> String.join(", ", plugin.getManager().homes()
+                        .getPublicHomes()
+                        .getOrDefault(player.getUsername(), List.of()));
+                case "ignoring_tp_requests" -> String.valueOf(plugin.getManager().requests()
+                        .isIgnoringRequests(player));
+                default -> null;
+            };
+
+            if (response == null) {
+                return PlaceholderResult.invalid("invaild argument for player!");
+            }
+
+            return PlaceholderResult.value(response);
+        });
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,5 @@ fabric_yarn_mappings=1.20.4+build.3
 fabric_api_version=0.95.4+1.20.4
 fabric_permissions_api_version=0.2-SNAPSHOT
 adventure_platform_fabric_version=5.11.0
+impactor_api_version=5.1.1-SNAPSHOT
+placeholder_api_version=2.3.0+1.20.3


### PR DESCRIPTION
This PR introduces support for the Impactor Economy and PlaceholderAPI in the mod, specifically tested on Minecraft version 1.20.1. The integration with Impactor is currently limited to version 1.20.1 due to its availability, but should remain compatible with future Impactor updates given their stable API history. The changes have been running smoothly on my server for a week without issues.

PlaceholderAPI: https://modrinth.com/mod/placeholder-api
Impactor: https://modrinth.com/mod/impactor