### PR TITLE
added reversePHomeNaming config option

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/command/PublicHomeCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/PublicHomeCommand.java
@@ -24,6 +24,9 @@ import net.william278.huskhomes.user.CommandUser;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.Optional;
+
+import static net.william278.huskhomes.position.Home.IDENTIFIER_DELIMITER;
 
 public class PublicHomeCommand extends HomeCommand implements TabProvider {
 
@@ -39,6 +42,16 @@ public class PublicHomeCommand extends HomeCommand implements TabProvider {
                     .ifPresent(command -> command.showPublicHomeList(executor, 1));
             return;
         }
+        if(plugin.getSettings().getGeneral().getNames().isReversePHomeNaming()) {
+            final Optional<String> name = parseStringArg(args, 0);
+            if (name.isPresent()) {
+                if (name.get().contains(IDENTIFIER_DELIMITER)) {
+                    String home = name.get().substring(0, name.get().indexOf(IDENTIFIER_DELIMITER));
+                    String owner = name.get().substring(name.get().indexOf(IDENTIFIER_DELIMITER) + 1);
+                    args[0] = owner + IDENTIFIER_DELIMITER + home;
+                }
+            }
+        }
         super.execute(executor, args);
     }
 
@@ -46,7 +59,12 @@ public class PublicHomeCommand extends HomeCommand implements TabProvider {
     @NotNull
     public List<String> suggest(@NotNull CommandUser executor, @NotNull String[] args) {
         if (args.length <= 2) {
-            return filter(plugin.getManager().homes().getPublicHomeIdentifiers(), args);
+            if(!plugin.getSettings().getGeneral().getNames().isReversePHomeNaming()){
+                return filter(plugin.getManager().homes().getPublicHomeIdentifiers(), args);
+            }
+            else{
+                return filter(plugin.getManager().homes().getPublicHomeIdentifiersReverse(), args);
+            }
         }
         return List.of();
     }

--- a/common/src/main/java/net/william278/huskhomes/command/PublicHomeListCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/PublicHomeListCommand.java
@@ -69,7 +69,8 @@ public class PublicHomeListCommand extends ListCommand {
         final PaginatedList homeList = PaginatedList.of(publicHomes.stream().map(home ->
                         plugin.getLocales()
                                 .getRawLocale("public_home_list_item",
-                                        Locales.escapeText(home.getName()), home.getSafeIdentifier(),
+                                        Locales.escapeText(home.getName()),
+                                        (plugin.getSettings().getGeneral().getNames().isReversePHomeNaming() ? home.getSafeIdentifierReverse() : home.getSafeIdentifier()),
                                         Locales.escapeText(home.getOwner().getUsername()),
                                         Locales.escapeText(home.getMeta().getDescription()))
                                 .orElse(home.getName())).sorted().collect(Collectors.toList()),

--- a/common/src/main/java/net/william278/huskhomes/config/Settings.java
+++ b/common/src/main/java/net/william278/huskhomes/config/Settings.java
@@ -179,6 +179,9 @@ public final class Settings {
 
             @Comment("Regex which home and warp names must match. Names have a max length of 16 characters")
             private String regex = "[a-zA-Z0-9-_]*";
+
+            @Comment("Whether to change the order of username and homename for phome commands default is Username.Homename, if true will be Homename.Username")
+            private boolean reversePHomeNaming = false;
         }
 
         @Comment("Settings for home and warp descriptions")

--- a/common/src/main/java/net/william278/huskhomes/manager/HomesManager.java
+++ b/common/src/main/java/net/william278/huskhomes/manager/HomesManager.java
@@ -98,6 +98,13 @@ public class HomesManager {
                 .toList();
     }
 
+    @NotNull
+    public List<String> getPublicHomeIdentifiersReverse() {
+        return publicHomes.stream()
+                .map(Home::getIdentifierReverse)
+                .toList();
+    }
+
     /**
      * Cache user homes for a given user.
      *

--- a/common/src/main/java/net/william278/huskhomes/position/Home.java
+++ b/common/src/main/java/net/william278/huskhomes/position/Home.java
@@ -137,6 +137,11 @@ public class Home extends SavedPosition {
         return getOwner().getUsername() + IDENTIFIER_DELIMITER + super.getSafeIdentifier();
     }
 
+    @NotNull
+    public String getSafeIdentifierReverse() {
+        return super.getSafeIdentifier() + IDENTIFIER_DELIMITER + getOwner().getUsername();
+    }
+
     /**
      * Get the canonical home identifier string.
      *
@@ -149,6 +154,11 @@ public class Home extends SavedPosition {
     @Override
     public String getIdentifier() {
         return getOwner().getUsername() + IDENTIFIER_DELIMITER + super.getIdentifier();
+    }
+
+    @NotNull
+    public String getIdentifierReverse() {
+        return super.getIdentifier() + IDENTIFIER_DELIMITER + getOwner().getUsername();
     }
 
 }


### PR DESCRIPTION
I added a config option that allows switching of the default phome naming scheme for commands "username.homename" to the reverse order "homename.username".
This can be preferable because it allows easier and faster usage of /phome for all those that can remember the name of the location (aka the home) they want to go to better then the name of the user that created the home.
Instead of having to remember that eg XPModder made the home for DT-HQ, to be able to do /phome XPModder.DT-HQ, with this config option set to true you instead use /phome DT-HQ.XPModder to get to the desired location. 
As this also works with tab completion, you dont have to remember the username of the creator of the home anymore as you can tab complete it after typing in the name (or start of the name) of the desired home.

Will, I did this for Dogcraft (obv), as pretty much everyone I have spoken to would like to be able to tab complete the phome command without having to remember or ask who the owner of the phome is.