### PR TITLE
Adjusting the permissions node for the /rtp command

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
@@ -72,7 +72,7 @@ public class RtpCommand extends Command implements UserListTabProvider {
             case 2 -> plugin.getWorlds().stream()
                     .filter(world -> !plugin.getSettings().getRtp().isWorldRtpRestricted(world))
                     .map(World::getName)
-                    .filter(world -> !user.hasPermission(getPermission(world))).toList();
+                    .filter(world -> user.hasPermission(getPermission(world))).toList();
             default -> null;
         };
     }

--- a/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
@@ -67,12 +67,12 @@ public class RtpCommand extends Command implements UserListTabProvider {
     @Override
     public List<String> suggest(@NotNull CommandUser user, @NotNull String[] args) {
         return switch (args.length) {
-            case 0, 1 -> user.hasPermission("other") ? UserListTabProvider.super.suggestLocal(args)
+            case 0, 1 -> user.hasPermission(getPermission("other")) ? UserListTabProvider.super.suggestLocal(args)
                     : user instanceof OnlineUser online ? List.of(online.getUsername()) : List.of();
             case 2 -> plugin.getWorlds().stream()
                     .filter(world -> !plugin.getSettings().getRtp().isWorldRtpRestricted(world))
                     .map(World::getName)
-                    .filter(world -> !user.hasPermission(world)).toList();
+                    .filter(world -> !user.hasPermission(getPermission("world"))).toList();
             default -> null;
         };
     }

--- a/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
@@ -72,7 +72,7 @@ public class RtpCommand extends Command implements UserListTabProvider {
             case 2 -> plugin.getWorlds().stream()
                     .filter(world -> !plugin.getSettings().getRtp().isWorldRtpRestricted(world))
                     .map(World::getName)
-                    .filter(user::hasPermission).toList();
+                    .filter(world -> !user.hasPermission(world)).toList();
             default -> null;
         };
     }

--- a/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
@@ -72,7 +72,7 @@ public class RtpCommand extends Command implements UserListTabProvider {
             case 2 -> plugin.getWorlds().stream()
                     .filter(world -> !plugin.getSettings().getRtp().isWorldRtpRestricted(world))
                     .map(World::getName)
-                    .filter(world -> !user.hasPermission(getPermission("world"))).toList();
+                    .filter(world -> !user.hasPermission(getPermission(world))).toList();
             default -> null;
         };
     }

--- a/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
@@ -37,7 +37,9 @@ public class RtpCommand extends Command implements UserListTabProvider {
         super("rtp", List.of(), "[player] [world]", plugin);
         Map<String, Boolean> map = new HashMap<>();
         map.put("other", true);
-        plugin.getWorlds().forEach(world -> map.put(world.getName(), true));
+        plugin.getWorlds().stream()
+                .filter(world -> !plugin.getSettings().getRtp().isWorldRtpRestricted(world))
+                .map(World::getName).toList().forEach(world -> map.put(world, true));
         addAdditionalPermissions(map);
     }
 


### PR DESCRIPTION
Remove the original permission node huskhomes.command.rtp.world and add the permission node huskhomes.command.rtp.<world>, where <world> can be changed to any of the server's worlds, and this permission node can grant the player the permission to be randomly teleported to a specified world