### PR TITLE
Add permission based tp cooldowns

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/teleport/TeleportBuilder.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/TeleportBuilder.java
@@ -30,7 +30,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A builder for {@link Teleport} and {@link TimedTeleport} objects.

--- a/common/src/main/java/net/william278/huskhomes/teleport/TeleportBuilder.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/TeleportBuilder.java
@@ -29,7 +29,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 /**
  * A builder for {@link Teleport} and {@link TimedTeleport} objects.
@@ -65,30 +64,9 @@ public class TeleportBuilder {
             throw new IllegalStateException("Teleporter must be an OnlineUser for timed teleportation");
         }
 
-        int warmupTime = -1;
-        for (Map.Entry<String, Boolean> entry : onlineTeleporter.getPermissions().entrySet()) {
-            if (!entry.getValue()) {
-                continue;
-            }
-            String perm = entry.getKey();
-            if (perm.startsWith("huskhomes.teleport_warmup.")) {
-                String[] split = perm.split("\\.");
-                if (split.length == 3) {
-                    try {
-                        int currTime = Integer.parseInt(split[2]);
-                        if (currTime > warmupTime) {
-                            warmupTime = currTime;
-                        }
-                    } catch (NumberFormatException ignored) {
-                        throw new IllegalStateException("Invalid warmup permission: " + perm);
-                    }
-                }
-            }
-        }
-
         return new TimedTeleport(
                 executor, onlineTeleporter, target, type,
-                warmupTime == -1 ? plugin.getSettings().getGeneral().getTeleportWarmupTime() : warmupTime,
+                onlineTeleporter.getMaxTeleportWarmup(plugin.getSettings().getGeneral().getTeleportWarmupTime()),
                 updateLastPosition, actions, plugin
         );
     }

--- a/common/src/main/java/net/william278/huskhomes/user/OnlineUser.java
+++ b/common/src/main/java/net/william278/huskhomes/user/OnlineUser.java
@@ -261,6 +261,20 @@ public abstract class OnlineUser extends User implements Teleportable, CommandUs
     }
 
     /**
+     * Get the largest permission node value for teleport warmup.
+     *
+     * @param defaultTeleportWarmup the default teleport warmup time, if no perms are set
+     * @return the largest permission node value for teleport warmup
+     */
+    public int getMaxTeleportWarmup(final int defaultTeleportWarmup) {
+        final List<Integer> homes = getNumericalPermissions("huskhomes.teleport_warmup.");
+        if (homes.isEmpty()) {
+            return defaultTeleportWarmup;
+        }
+        return homes.get(0);
+    }
+
+    /**
      * Get the number of free home slots this user may set.
      *
      * @param defaultFreeHomes the default number of free home slots to give this user


### PR DESCRIPTION
Adds so if a player has huskhomes.teleport_warmup.XX permission it uses that over the configurated cooldown, this allows to set things like per world cooldows or similiar things.

About the code: Wasnt sure how to make it very clean thats why it is the way it is