### PR TITLE
fix: #658 Retry when the table is locked

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/database/MySqlDatabase.java
+++ b/common/src/main/java/net/william278/huskhomes/database/MySqlDatabase.java
@@ -189,7 +189,33 @@ public class MySqlDatabase extends Database {
             statement.setString(7, position.getWorld().getName());
             statement.setString(8, position.getServer());
             statement.setDouble(9, positionId);
-            statement.executeUpdate();
+            int retryCount = 0;
+            boolean success = false;
+            while (retryCount < 20 && !success) {
+                try {
+                    statement.executeUpdate();
+                    success = true;
+                } catch (SQLException e) {
+                    if (e.getMessage().contains("locked")) {
+                        // Proper handling of table locking exceptions to prevent database disconnections
+                        retryCount++;
+                        plugin.log(Level.WARNING, "Database lock encountered, retrying update position...");
+                        try {
+                            Thread.sleep(500);
+                        } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                            plugin.log(Level.SEVERE, "Thread was interrupted during retry wait", ie);
+                            break;
+                        }
+                    } else {
+                        // Throw the exception if it's not a lock issue
+                        throw e;
+                    }
+                }
+            }
+            if (!success) {
+                plugin.log(Level.SEVERE, "Failed to update position after 20 retries due to database lock!");
+            }
         }
     }
 


### PR DESCRIPTION
Fix #658

Proper handling of table locking exceptions to prevent database disconnections.

When a table lock exception is thrown, it will attempt to **retry** once **after 500 ms**, for a **total of 20 retries**. **Other SQLExceptions** will be **thrown directly** to allow for handling at the upper execution stack.

Tests well on my server's production environment.

Please note that I am not a professional Java programmer, but this issue is quite serious and I urgently need to fix it on my server. Therefore, I have made an attempt to repair the code and I'm sharing my code behind the fix.

If there are any issues with my code, please make the necessary corrections. Thank you!