### PR TITLE
Add a separate event for random teleport

### DIFF
--- a/bukkit/src/main/java/net/william278/huskhomes/event/BukkitEventDispatcher.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/event/BukkitEventDispatcher.java
@@ -46,7 +46,11 @@ public interface BukkitEventDispatcher extends EventDispatcher {
     @Override
     @NotNull
     default ITeleportEvent getTeleportEvent(@NotNull Teleport teleport) {
-        return teleport.getType() == Teleport.Type.BACK ? new TeleportBackEvent(teleport) : new TeleportEvent(teleport);
+        return switch (teleport.getType()) {
+            case BACK -> new TeleportBackEvent(teleport);
+            case RANDOM_TELEPORT -> new RandomTeleportEvent(teleport);
+            default -> new TeleportEvent(teleport);
+        };
     }
 
     @Override

--- a/bukkit/src/main/java/net/william278/huskhomes/event/RandomTeleportEvent.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/event/RandomTeleportEvent.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package net.william278.huskhomes.event;
 
 import net.william278.huskhomes.position.Position;

--- a/bukkit/src/main/java/net/william278/huskhomes/event/RandomTeleportEvent.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/event/RandomTeleportEvent.java
@@ -1,0 +1,31 @@
+package net.william278.huskhomes.event;
+
+import net.william278.huskhomes.position.Position;
+import net.william278.huskhomes.teleport.Teleport;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class RandomTeleportEvent extends TeleportEvent implements IRandomTeleportEvent, Cancellable {
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    public RandomTeleportEvent(@NotNull Teleport teleport) {
+        super(teleport);
+    }
+
+    @Override
+    @NotNull
+    public Position getPosition() {
+        return (Position) getTeleport().getTarget();
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    @SuppressWarnings("unused")
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/common/src/main/java/net/william278/huskhomes/command/RTPCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/RTPCommand.java
@@ -189,6 +189,7 @@ public class RTPCommand extends Command implements UserListTabProvider {
                     // Build and execute the teleport
                     final TeleportBuilder builder = Teleport.builder(plugin)
                             .teleporter(teleporter)
+                            .type(Teleport.Type.RANDOM_TELEPORT)
                             .actions(TransactionResolver.Action.RANDOM_TELEPORT)
                             .target(position.get());
                     builder.buildAndComplete(executor.equals(teleporter), args);

--- a/common/src/main/java/net/william278/huskhomes/event/IRandomTeleportEvent.java
+++ b/common/src/main/java/net/william278/huskhomes/event/IRandomTeleportEvent.java
@@ -1,0 +1,11 @@
+package net.william278.huskhomes.event;
+
+import net.william278.huskhomes.position.Position;
+import org.jetbrains.annotations.NotNull;
+
+public interface IRandomTeleportEvent extends ITeleportEvent {
+
+    @NotNull
+    Position getPosition();
+
+}

--- a/common/src/main/java/net/william278/huskhomes/event/IRandomTeleportEvent.java
+++ b/common/src/main/java/net/william278/huskhomes/event/IRandomTeleportEvent.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package net.william278.huskhomes.event;
 
 import net.william278.huskhomes.position.Position;

--- a/common/src/main/java/net/william278/huskhomes/teleport/Teleport.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/Teleport.java
@@ -203,7 +203,8 @@ public class Teleport implements Completable {
     public enum Type {
         TELEPORT(0),
         RESPAWN(1),
-        BACK(2);
+        BACK(2),
+        RANDOM_TELEPORT(3);
 
         private final int typeId;
 

--- a/fabric/src/main/java/net/william278/huskhomes/event/RandomTeleportCallback.java
+++ b/fabric/src/main/java/net/william278/huskhomes/event/RandomTeleportCallback.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package net.william278.huskhomes.event;
 
 import net.fabricmc.fabric.api.event.Event;
@@ -11,7 +30,7 @@ import java.util.function.Function;
 
 public interface RandomTeleportCallback extends FabricEventCallback<IRandomTeleportEvent> {
     @NotNull
-    net.fabricmc.fabric.api.event.Event<RandomTeleportCallback> EVENT = EventFactory.createArrayBacked(RandomTeleportCallback.class,
+    Event<RandomTeleportCallback> EVENT = EventFactory.createArrayBacked(RandomTeleportCallback.class,
             (listeners) -> (event) -> {
                 for (RandomTeleportCallback listener : listeners) {
                     final ActionResult result = listener.invoke(event);

--- a/fabric/src/main/java/net/william278/huskhomes/event/RandomTeleportCallback.java
+++ b/fabric/src/main/java/net/william278/huskhomes/event/RandomTeleportCallback.java
@@ -1,0 +1,61 @@
+package net.william278.huskhomes.event;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.util.ActionResult;
+import net.william278.huskhomes.position.Position;
+import net.william278.huskhomes.teleport.Teleport;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Function;
+
+public interface RandomTeleportCallback extends FabricEventCallback<IRandomTeleportEvent> {
+    @NotNull
+    net.fabricmc.fabric.api.event.Event<RandomTeleportCallback> EVENT = EventFactory.createArrayBacked(RandomTeleportCallback.class,
+            (listeners) -> (event) -> {
+                for (RandomTeleportCallback listener : listeners) {
+                    final ActionResult result = listener.invoke(event);
+                    if (event.isCancelled()) {
+                        return ActionResult.FAIL;
+                    } else if (result == ActionResult.FAIL) {
+                        event.setCancelled(true);
+                        return result;
+                    }
+                }
+
+                return ActionResult.PASS;
+            });
+
+    @NotNull
+    Function<Teleport, IRandomTeleportEvent> SUPPLIER = (teleport) ->
+            new IRandomTeleportEvent() {
+                private boolean cancelled = false;
+
+                @Override
+                @NotNull
+                public Position getPosition() {
+                    return (Position) getTeleport().getTarget();
+                }
+
+                @Override
+                @NotNull
+                public Teleport getTeleport() {
+                    return teleport;
+                }
+
+                @Override
+                public void setCancelled(boolean cancelled) {
+                    this.cancelled = cancelled;
+                }
+
+                @Override
+                public boolean isCancelled() {
+                    return cancelled;
+                }
+
+                public @NotNull Event<RandomTeleportCallback> getEvent() {
+                    return EVENT;
+                }
+
+            };
+}

--- a/sponge/src/main/java/net/william278/huskhomes/event/SpongeEventDispatcher.java
+++ b/sponge/src/main/java/net/william278/huskhomes/event/SpongeEventDispatcher.java
@@ -46,7 +46,8 @@ public interface SpongeEventDispatcher extends EventDispatcher {
     @Override
     @NotNull
     default ITeleportEvent getTeleportEvent(@NotNull Teleport teleport) {
-        return new SpongeTeleportEvent(teleport);
+        return teleport.getType() == Teleport.Type.RANDOM_TELEPORT ? new SpongeRandomTeleportEvent(teleport) :
+                new SpongeTeleportEvent(teleport);
     }
 
     @Override

--- a/sponge/src/main/java/net/william278/huskhomes/event/SpongeRandomTeleportEvent.java
+++ b/sponge/src/main/java/net/william278/huskhomes/event/SpongeRandomTeleportEvent.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package net.william278.huskhomes.event;
+
+import net.william278.huskhomes.teleport.Teleport;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.Cause;
+import org.spongepowered.api.event.Event;
+
+public class SpongeRandomTeleportEvent implements IRandomTeleportEvent, Event, Cancellable {
+
+    private boolean cancelled = false;
+    private final Teleport teleport;
+
+    public SpongeRandomTeleportEvent(@NotNull Teleport teleport) {
+        this.teleport = teleport;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @NotNull
+    @Override
+    public Teleport getTeleport() {
+        return teleport;
+    }
+
+    @Override
+    public Cause cause() {
+        return Cause.builder()
+                .append(teleport.getTeleporter())
+                .build();
+    }
+
+}

--- a/sponge/src/main/java/net/william278/huskhomes/event/SpongeRandomTeleportEvent.java
+++ b/sponge/src/main/java/net/william278/huskhomes/event/SpongeRandomTeleportEvent.java
@@ -19,6 +19,7 @@
 
 package net.william278.huskhomes.event;
 
+import net.william278.huskhomes.position.Position;
 import net.william278.huskhomes.teleport.Teleport;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.api.event.Cancellable;
@@ -57,4 +58,8 @@ public class SpongeRandomTeleportEvent implements IRandomTeleportEvent, Event, C
                 .build();
     }
 
+    @Override
+    public @NotNull Position getPosition() {
+        return (Position) teleport.getTarget();
+    }
 }


### PR DESCRIPTION
As the title suggests, an event added to make it easier to listen for random teleport (actually my plugin needs to listen for random teleport, it seems to work well on the bukkit platform)