### PR TITLE
Enhance /rtp Command with Flexible World and Server Options, Fix Cross-Server Compatibility

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/api/BaseHuskHomesAPI.java
+++ b/common/src/main/java/net/william278/huskhomes/api/BaseHuskHomesAPI.java
@@ -810,7 +810,7 @@ public class BaseHuskHomesAPI {
                                              @NotNull String... rtpArgs) {
         if (plugin.getSettings().getRtp().isCrossServer() && (plugin.getSettings().getCrossServer().isEnabled() &&
                                                               plugin.getSettings().getCrossServer().getBrokerType() == Broker.Type.REDIS)) {
-            List<String> allowedServers = plugin.getSettings().getRtp().getRandomTargetServers();
+            List<String> allowedServers = new ArrayList<>(plugin.getSettings().getRtp().getRandomTargetServers().keySet());
             String randomServer = allowedServers.get(random.nextInt(allowedServers.size()));
             if (randomServer.equals(plugin.getServerName())) {
                 randomlyTeleportPlayerLocally(user, timedTeleport, rtpArgs);

--- a/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
@@ -41,7 +41,7 @@ public class RtpCommand extends Command implements UserListTabCompletable {
     protected RtpCommand(@NotNull HuskHomes plugin) {
         super(
                 List.of("rtp"),
-                "[player] [world/server] [server]",
+                "[player] [world/server] [server (optional)]",
                 plugin
         );
 

--- a/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
@@ -41,7 +41,7 @@ public class RtpCommand extends Command implements UserListTabCompletable {
     protected RtpCommand(@NotNull HuskHomes plugin) {
         super(
                 List.of("rtp"),
-                "[player] [world/server] [server (optional)]",
+                "[player] [<world> [server]|<world>]",
                 plugin
         );
 
@@ -126,8 +126,8 @@ public class RtpCommand extends Command implements UserListTabCompletable {
                 yield possibleSuggestions;
             }
             case 3 -> {
-                // If argTwo is a world, suggest servers that contain the world
-                String argTwo = args[1];
+                // If worldName is a world, suggest servers that contain the world
+                String worldName = args[1];
 
                 List<String> possibleSuggestions = new ArrayList<>(plugin.getWorlds().stream()
                         .filter(world -> !plugin.getSettings().getRtp().isWorldRtpRestricted(world))
@@ -135,9 +135,9 @@ public class RtpCommand extends Command implements UserListTabCompletable {
                         .filter(world -> user.hasPermission(getPermission(world)))
                         .toList());
 
-                if (possibleSuggestions.contains(argTwo)) {
+                if (possibleSuggestions.contains(worldName)) {
                     yield plugin.getSettings().getRtp().getRandomTargetServers().entrySet().stream()
-                            .filter(entry -> entry.getValue().contains(argTwo))
+                            .filter(entry -> entry.getValue().contains(worldName))
                             .map(Map.Entry::getKey)
                             .toList();
                 }

--- a/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
@@ -32,10 +32,7 @@ import net.william278.huskhomes.util.TransactionResolver;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Random;
+import java.util.*;
 
 public class RtpCommand extends Command implements UserListTabCompletable {
 
@@ -44,7 +41,7 @@ public class RtpCommand extends Command implements UserListTabCompletable {
     protected RtpCommand(@NotNull HuskHomes plugin) {
         super(
                 List.of("rtp"),
-                "[player] [world]",
+                "[player] [world/server] [server (optional)]",
                 plugin
         );
 
@@ -69,10 +66,29 @@ public class RtpCommand extends Command implements UserListTabCompletable {
             return;
         }
 
-        // Validate, then execute the RTP
         final OnlineUser teleporter = optionalTeleporter.get();
-        this.validateRtp(teleporter, executor, args.length > 1 ? removeFirstArg(args) : args)
-                .ifPresent(world -> this.executeRtp(teleporter, executor, world, args));
+
+        // Determine the target world and server based on the command arguments
+        String worldName = teleporter.getPosition().getWorld().getName();
+        String targetServer = null;
+
+        if (args.length == 2) {
+            // If there's only one argument after the player name, it could be either a world or a server
+            if (plugin.getSettings().getRtp().getRandomTargetServers().containsKey(args[1])) {
+                targetServer = args[1];
+                worldName = teleporter.getPosition().getWorld().getName();
+            } else {
+                worldName = args[1];
+            }
+        } else if (args.length > 2) {
+            // If two arguments are provided after the player name, treat them as world and server
+            worldName = args[1];
+            targetServer = args[2];
+        }
+
+        // Validate world and server, and execute RTP
+        Optional<Map.Entry<World, String>> validatedTarget = validateRtp(teleporter, executor, worldName, targetServer);
+        validatedTarget.ifPresent(entry -> executeRtp(teleporter, executor, entry.getKey(), entry.getValue(), args));
     }
 
     @Nullable
@@ -82,24 +98,72 @@ public class RtpCommand extends Command implements UserListTabCompletable {
             case 0, 1 -> user.hasPermission(getPermission("other"))
                     ? UserListTabCompletable.super.suggest(user, args)
                     : user instanceof OnlineUser online ? List.of(online.getName()) : List.of();
-            case 2 -> plugin.getWorlds().stream()
-                    .filter(world -> !plugin.getSettings().getRtp().isWorldRtpRestricted(world))
-                    .map(World::getName)
-                    .filter(world -> user.hasPermission(getPermission(world))).toList();
+
+            case 2 -> {
+                String input = args[1].toLowerCase();
+
+                // Check if the input could be a world or a server name
+                List<String> possibleSuggestions = new ArrayList<>();
+
+                // Suggest available servers if user has permission
+                possibleSuggestions.addAll(plugin.getSettings().getRtp().getRandomTargetServers().keySet().stream()
+                        .filter(server -> user.hasPermission(getPermission(server)))
+                        .toList());
+
+                // Additionally suggest worlds that the user has permission to RTP into
+                possibleSuggestions.addAll(plugin.getWorlds().stream()
+                        .filter(world -> !plugin.getSettings().getRtp().isWorldRtpRestricted(world))
+                        .map(World::getName)
+                        .filter(world -> user.hasPermission(getPermission(world)))
+                        .toList());
+
+                if (!input.isEmpty()) {
+                    yield possibleSuggestions.stream()
+                            .filter(suggestion -> suggestion.toLowerCase().startsWith(input))
+                            .toList();
+                }
+
+                yield possibleSuggestions;
+            }
+            case 3 -> {
+                // If argTwo is a world, suggest servers that contain the world
+                String argTwo = args[1];
+
+                List<String> possibleSuggestions = new ArrayList<>(plugin.getWorlds().stream()
+                        .filter(world -> !plugin.getSettings().getRtp().isWorldRtpRestricted(world))
+                        .map(World::getName)
+                        .filter(world -> user.hasPermission(getPermission(world)))
+                        .toList());
+
+                if (possibleSuggestions.contains(argTwo)) {
+                    yield plugin.getSettings().getRtp().getRandomTargetServers().entrySet().stream()
+                            .filter(entry -> entry.getValue().contains(argTwo))
+                            .map(Map.Entry::getKey)
+                            .toList();
+                }
+
+                yield List.of();
+            }
+
             default -> null;
         };
     }
 
+
+
     /**
-     * Validates the RTP command, returning the world to randomly teleport in if successful.
+     * Validates the RTP target world and server based on arguments, ensuring the server contains the target world.
+     * - If no server is specified, randomly selects a server containing the world.
+     * - Returns both the validated world and server as a pair.
      *
-     * @param teleporter The user to teleport
-     * @param executor   The user executing the command
-     * @param args       The command arguments
-     * @return The world to randomly teleport in, if successful
+     * @param teleporter   The player to teleport
+     * @param executor     The player executing the command
+     * @param worldName    The world name to teleport to
+     * @param targetServer The server name to teleport to (optional)
+     * @return A pair of the target world and server to use for teleportation, if valid
      */
-    private Optional<World> validateRtp(@NotNull OnlineUser teleporter, @NotNull CommandUser executor,
-                                        @NotNull String[] args) {
+    private Optional<Map.Entry<World, String>> validateRtp(@NotNull OnlineUser teleporter, @NotNull CommandUser executor,
+                                                           @NotNull String worldName, @Nullable String targetServer) {
         // Check permissions if the user is being teleported by another player
         if (!executor.equals(teleporter) && !executor.hasPermission(getPermission("other"))) {
             plugin.getLocales().getLocale("error_no_permission")
@@ -112,58 +176,59 @@ public class RtpCommand extends Command implements UserListTabCompletable {
             return Optional.empty();
         }
 
-        // Determine the world to carry out the RTP in
-        final World teleporterWorld = teleporter.getPosition().getWorld();
-        final Optional<World> optionalWorld = args.length >= 1 ? plugin.getWorlds().stream().filter(w -> w.getName()
-                .equalsIgnoreCase(args[0])).findFirst() : Optional.of(teleporterWorld);
-        if (optionalWorld.isEmpty()) {
-            plugin.getLocales().getLocale("error_invalid_world", args[0])
+        Map<String, List<String>> randomTargetServers = plugin.getSettings().getRtp().getRandomTargetServers();
+
+        // Get a list of servers that have the specified world
+        List<String> eligibleServers = randomTargetServers.entrySet().stream()
+                .filter(entry -> entry.getValue().contains(worldName))
+                .map(Map.Entry::getKey)
+                .toList();
+
+        // If targetServer is specified, validate it; otherwise, pick a random eligible server
+        String selectedServer = targetServer != null ? targetServer :
+                (!eligibleServers.isEmpty() ? eligibleServers.get(random.nextInt(eligibleServers.size())) : null);
+
+        // If no server found or the specified server is invalid, return an error
+        if (selectedServer == null || (targetServer != null && !eligibleServers.contains(targetServer))) {
+            plugin.getLocales().getLocale("error_invalid_world", worldName)
                     .ifPresent(executor::sendMessage);
             return Optional.empty();
         }
 
-        // Ensure the user has permission to randomly teleport in the world
-        final World world = optionalWorld.get();
-        if (!world.equals(teleporterWorld) && !executor.hasPermission(getPermission(world.getName()))) {
-            plugin.getLocales().getLocale("error_no_permission")
-                    .ifPresent(executor::sendMessage);
-            return Optional.empty();
-        }
-        if (plugin.getSettings().getRtp().isWorldRtpRestricted(world)) {
-            plugin.getLocales().getLocale("error_rtp_restricted_world")
-                    .ifPresent(executor::sendMessage);
-            return Optional.empty();
-        }
+        Optional<World> targetWorld = plugin.getWorlds().stream()
+                .filter(world -> world.getName().equalsIgnoreCase(worldName))
+                .findFirst()
+                .or(() -> Optional.of(World.from(worldName, UUID.randomUUID())));
 
-        return Optional.of(world);
+        return targetWorld.map(world -> new AbstractMap.SimpleEntry<>(world, selectedServer));
     }
 
     /**
-     * Executes the random teleport.
+     * Executes the RTP, handling both local and cross-server teleportation.
+     * Uses the validated world-server pair from validateRtp.
      *
-     * @param teleporter The player to teleport
-     * @param executor   The player executing the command
-     * @param world      The world to teleport in
+     * @param teleporter   The player to teleport
+     * @param executor     The player executing the command
+     * @param world        The validated world to teleport to
+     * @param targetServer The validated server to teleport to
      * @param args       Arguments to pass to the RTP engine
      */
-    private void executeRtp(@NotNull OnlineUser teleporter, @NotNull CommandUser executor, @NotNull World world,
-                            @NotNull String[] args) {
+    private void executeRtp(@NotNull OnlineUser teleporter, @NotNull CommandUser executor,
+                            @NotNull World world, @NotNull String targetServer, @NotNull String[] args) {
         // Generate a random position
         plugin.getLocales().getLocale("teleporting_random_generation")
                 .ifPresent(teleporter::sendMessage);
 
         if (plugin.getSettings().getRtp().isCrossServer() && plugin.getSettings().getCrossServer().isEnabled()
-            && plugin.getSettings().getCrossServer().getBrokerType() == Broker.Type.REDIS) {
-            List<String> allowedServers = plugin.getSettings().getRtp().getRandomTargetServers();
-            String randomServer = allowedServers.get(random.nextInt(allowedServers.size()));
-            if (randomServer.equals(plugin.getServerName())) {
+                && plugin.getSettings().getCrossServer().getBrokerType() == Broker.Type.REDIS) {
+            if (targetServer.equals(plugin.getServerName())) {
                 performLocalRTP(teleporter, executor, world, args);
                 return;
             }
 
             plugin.getBroker().ifPresent(b -> Message.builder()
                     .type(Message.MessageType.REQUEST_RTP_LOCATION)
-                    .target(randomServer, Message.TargetType.SERVER)
+                    .target(targetServer, Message.TargetType.SERVER)
                     .payload(Payload.string(world.getName()))
                     .build().send(b, teleporter));
             return;

--- a/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
@@ -41,7 +41,7 @@ public class RtpCommand extends Command implements UserListTabCompletable {
     protected RtpCommand(@NotNull HuskHomes plugin) {
         super(
                 List.of("rtp"),
-                "[player] [world/server] [server (optional)]",
+                "[player] [world/server] [server]",
                 plugin
         );
 

--- a/common/src/main/java/net/william278/huskhomes/config/Settings.java
+++ b/common/src/main/java/net/william278/huskhomes/config/Settings.java
@@ -346,7 +346,9 @@ public final class Settings {
 
         @Comment({"List of server in which /rtp is allowed. (Only relevant when using cross server mode WITH REDIS)",
                 "If a server is not defined here the RTP logic has no way of knowing its existence."})
-        private List<String> randomTargetServers = List.of("server-01", "server-02");
+        private Map<String, List<String>> randomTargetServers = new HashMap<>(
+                Map.of("survival_server", List.of("world", "world_nether", "world_the_end"))
+        );
     }
 
     @Comment("Action cooldown settings. Docs: https://william278.net/docs/huskhomes/cooldowns")

--- a/common/src/main/java/net/william278/huskhomes/network/MessageHandler.java
+++ b/common/src/main/java/net/william278/huskhomes/network/MessageHandler.java
@@ -130,6 +130,7 @@ public interface MessageHandler {
                 .orElse(CompletableFuture.completedFuture(Optional.empty()))
                 .thenAccept(
                         (teleport) -> Message.builder()
+                                .type(Message.MessageType.RTP_LOCATION)
                                 .target(message.getSender(), Message.TargetType.PLAYER)
                                 .payload(Payload.position(teleport.orElse(null)))
                                 .build().send(getBroker(), null)

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -1,7 +1,10 @@
-HuskHomes provides a range of commands for you to use. This page will detail the permissions for each command to [let you manage access](managing-access) to the plugin's different features.
+HuskHomes provides a range of commands for you to use. This page will detail the permissions for each command
+to [let you manage access](managing-access) to the plugin's different features.
 
 ## Commands & Permissions Table
-> **Command Conflicts:** If you have multiple plugins providing similar commands, you may need to [create aliases](command-conflicts) to ensure HuskHomes' commands take priority.
+
+> **Command Conflicts:** If you have multiple plugins providing similar commands, you may need
+> to [create aliases](command-conflicts) to ensure HuskHomes' commands take priority.
 
 <table align="right">
     <thead>
@@ -13,7 +16,8 @@ HuskHomes provides a range of commands for you to use. This page will detail the
     </tbody>
 </table>
 
-This is a table of HuskHomes commands, how to use them, and their required permission nodes. Additional permissions for bypassing teleport warmup and economy checks are detailed below.
+This is a table of HuskHomes commands, how to use them, and their required permission nodes. Additional permissions for
+bypassing teleport warmup and economy checks are detailed below.
 
 <table>
     <thead>
@@ -322,21 +326,33 @@ This is a table of HuskHomes commands, how to use them, and their required permi
         <!-- /rtp command -->
         <tr><th colspan="5">Random teleport command</th></tr>
         <tr>
-            <td rowspan="3"><code>/rtp</code></td>
+            <td rowspan="5"><code>/rtp</code></td>
             <td><code>/rtp</code></td>
-            <td>Teleport randomly into the wild</td>
+            <td>Teleport randomly into the wild in the current world</td>
             <td><code>huskhomes.command.rtp</code></td>
             <td align="center">✅</td>
         </tr>
         <tr>
             <td><code>/rtp &lt;player&gt;</code></td>
-            <td>Teleport another user randomly into the wild</td>
+            <td>Teleport another player randomly into the wild</td>
             <td><code>huskhomes.command.rtp.other</code></td>
             <td align="center">❌</td>
         </tr>
         <tr>
-            <td><code>/rtp &lt;player&gt; &lt;world&gt;</code></td>
-            <td>Teleport randomly in a specific world</td>
+            <td><code>/rtp &lt;world&gt;</code></td>
+            <td>Teleport randomly in a specified world</td>
+            <td><code>huskhomes.command.rtp.world</code></td>
+            <td align="center">❌</td>
+        </tr>
+        <tr>
+            <td><code>/rtp &lt;world&gt; &lt;server&gt;</code></td>
+            <td>Teleport randomly in a specified world on a specified server</td>
+            <td><code>huskhomes.command.rtp.world</code></td>
+            <td align="center">❌</td>
+        </tr>
+        <tr>
+            <td><code>/rtp &lt;server&gt;</code></td>
+            <td>Teleport randomly in the current world on a specified server</td>
             <td><code>huskhomes.command.rtp.world</code></td>
             <td align="center">❌</td>
         </tr>
@@ -421,11 +437,14 @@ This is a table of HuskHomes commands, how to use them, and their required permi
 </table>
 
 ### Notes
-&dagger; &mdash; If [Permission Restricted Warps](restricted-warps) are in use, the  `huskhomes.command.warp.(warp_name)` permission node will also be required to be able to view and use warps.
+
+&dagger; &mdash; If [Permission Restricted Warps](restricted-warps) are in use, the
+`huskhomes.command.warp.(warp_name)` permission node will also be required to be able to view and use warps.
 
 &ddagger; &mdash; Requires `return_by_death` to be enabled in [`config.yml`](config-files).
 
 ### Command Aliases
+
 The following commands have aliases that can also be used for convenience:
 
 | Command      | Aliases                      |
@@ -440,7 +459,8 @@ The following commands have aliases that can also be used for convenience:
 
 ## Disabling commands
 
-If you'd like to disable a command, add it to the `disabled_commands` section of your config file as detailed below and the command will not be registered.
+If you'd like to disable a command, add it to the `disabled_commands` section of your config file as detailed below and
+the command will not be registered.
 
 <details>
 <summary>Disabling a command in config.yml</summary>
@@ -453,19 +473,26 @@ disabled_commands: [ '/rtp' ]
 </details>
 
 ## Home limits
-You can modify the maximum number of homes, the allotment of free homes and the number of public homes a user can set through permission nodes.
+
+You can modify the maximum number of homes, the allotment of free homes and the number of public homes a user can set
+through permission nodes.
 
 * `huskhomes.max_homes.<amount>` — Determines the max number of homes a user can set
-* `huskhomes.free_homes.<amount>` — Determines the allotment of homes the user can set for free, before they have to pay&dagger;
+* `huskhomes.free_homes.<amount>` — Determines the allotment of homes the user can set for free, before they have to
+  pay&dagger;
 * `huskhomes.max_public_homes.<amount>` — Determines the maximum number of homes a user can make public
 
 &dagger;Only effective on servers that make use of the economy hook.
 
-If users have multiple permission nodes (i.e. from being in multiple permission groups), HuskHomes will accept the highest. If you prefer that the nodes _stack_, you can set the `stack_permission_limits` setting in the plugin config file to `true` (under `general`).
+If users have multiple permission nodes (i.e. from being in multiple permission groups), HuskHomes will accept the
+highest. If you prefer that the nodes _stack_, you can set the `stack_permission_limits` setting in the plugin config
+file to `true` (under `general`).
 
-Note that these permission-set values override the values set in the plugin config (`max_homes`, `max_public_homes` under `general` and `free_homes` under `economy`).
+Note that these permission-set values override the values set in the plugin config (`max_homes`, `max_public_homes`
+under `general` and `free_homes` under `economy`).
 
 ## Teleport warmup times
+
 You can change the teleport warmup time based on a permission node:
 
 * `huskhomes.teleport_warmup.<seconds>` — Determines how long this player has to wait before teleporting.
@@ -482,4 +509,5 @@ These permissions let you bypass teleportation warmup checks, cooldown, and econ
 | Bypass [cooldown checks](cooldowns)        | `huskhomes.bypass_cooldowns`       | Not set |
 | Bypass [economy checks](economy-hook)      | `huskhomes.bypass_economy_checks`  | Not set |
 
-&dagger;This is not effective when the teleport warmup time is set to `<= 0` in the config file. This permission also bypasses the numerical teleport warmup time permission detailed above.
+&dagger;This is not effective when the teleport warmup time is set to `<= 0` in the config file. This permission also
+bypasses the numerical teleport warmup time permission detailed above.

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -322,21 +322,33 @@ This is a table of HuskHomes commands, how to use them, and their required permi
         <!-- /rtp command -->
         <tr><th colspan="5">Random teleport command</th></tr>
         <tr>
-            <td rowspan="3"><code>/rtp</code></td>
+            <td rowspan="5"><code>/rtp</code></td>
             <td><code>/rtp</code></td>
-            <td>Teleport randomly into the wild</td>
+            <td>Teleport randomly into the wild in the current world</td>
             <td><code>huskhomes.command.rtp</code></td>
             <td align="center">✅</td>
         </tr>
         <tr>
             <td><code>/rtp &lt;player&gt;</code></td>
-            <td>Teleport another user randomly into the wild</td>
+            <td>Teleport another player randomly into the wild</td>
             <td><code>huskhomes.command.rtp.other</code></td>
             <td align="center">❌</td>
         </tr>
         <tr>
-            <td><code>/rtp &lt;player&gt; &lt;world&gt;</code></td>
-            <td>Teleport randomly in a specific world</td>
+            <td><code>/rtp &lt;world&gt;</code></td>
+            <td>Teleport randomly in a specified world</td>
+            <td><code>huskhomes.command.rtp.world</code></td>
+            <td align="center">❌</td>
+        </tr>
+        <tr>
+            <td><code>/rtp &lt;world&gt; &lt;server&gt;</code></td>
+            <td>Teleport randomly in a specified world on a specified server</td>
+            <td><code>huskhomes.command.rtp.world</code></td>
+            <td align="center">❌</td>
+        </tr>
+        <tr>
+            <td><code>/rtp &lt;server&gt;</code></td>
+            <td>Teleport randomly in the current world on a specified server</td>
             <td><code>huskhomes.command.rtp.world</code></td>
             <td align="center">❌</td>
         </tr>

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -1,10 +1,7 @@
-HuskHomes provides a range of commands for you to use. This page will detail the permissions for each command
-to [let you manage access](managing-access) to the plugin's different features.
+HuskHomes provides a range of commands for you to use. This page will detail the permissions for each command to [let you manage access](managing-access) to the plugin's different features.
 
 ## Commands & Permissions Table
-
-> **Command Conflicts:** If you have multiple plugins providing similar commands, you may need
-> to [create aliases](command-conflicts) to ensure HuskHomes' commands take priority.
+> **Command Conflicts:** If you have multiple plugins providing similar commands, you may need to [create aliases](command-conflicts) to ensure HuskHomes' commands take priority.
 
 <table align="right">
     <thead>
@@ -16,8 +13,7 @@ to [let you manage access](managing-access) to the plugin's different features.
     </tbody>
 </table>
 
-This is a table of HuskHomes commands, how to use them, and their required permission nodes. Additional permissions for
-bypassing teleport warmup and economy checks are detailed below.
+This is a table of HuskHomes commands, how to use them, and their required permission nodes. Additional permissions for bypassing teleport warmup and economy checks are detailed below.
 
 <table>
     <thead>
@@ -326,33 +322,21 @@ bypassing teleport warmup and economy checks are detailed below.
         <!-- /rtp command -->
         <tr><th colspan="5">Random teleport command</th></tr>
         <tr>
-            <td rowspan="5"><code>/rtp</code></td>
+            <td rowspan="3"><code>/rtp</code></td>
             <td><code>/rtp</code></td>
-            <td>Teleport randomly into the wild in the current world</td>
+            <td>Teleport randomly into the wild</td>
             <td><code>huskhomes.command.rtp</code></td>
             <td align="center">✅</td>
         </tr>
         <tr>
             <td><code>/rtp &lt;player&gt;</code></td>
-            <td>Teleport another player randomly into the wild</td>
+            <td>Teleport another user randomly into the wild</td>
             <td><code>huskhomes.command.rtp.other</code></td>
             <td align="center">❌</td>
         </tr>
         <tr>
-            <td><code>/rtp &lt;world&gt;</code></td>
-            <td>Teleport randomly in a specified world</td>
-            <td><code>huskhomes.command.rtp.world</code></td>
-            <td align="center">❌</td>
-        </tr>
-        <tr>
-            <td><code>/rtp &lt;world&gt; &lt;server&gt;</code></td>
-            <td>Teleport randomly in a specified world on a specified server</td>
-            <td><code>huskhomes.command.rtp.world</code></td>
-            <td align="center">❌</td>
-        </tr>
-        <tr>
-            <td><code>/rtp &lt;server&gt;</code></td>
-            <td>Teleport randomly in the current world on a specified server</td>
+            <td><code>/rtp &lt;player&gt; &lt;world&gt;</code></td>
+            <td>Teleport randomly in a specific world</td>
             <td><code>huskhomes.command.rtp.world</code></td>
             <td align="center">❌</td>
         </tr>
@@ -437,14 +421,11 @@ bypassing teleport warmup and economy checks are detailed below.
 </table>
 
 ### Notes
-
-&dagger; &mdash; If [Permission Restricted Warps](restricted-warps) are in use, the
-`huskhomes.command.warp.(warp_name)` permission node will also be required to be able to view and use warps.
+&dagger; &mdash; If [Permission Restricted Warps](restricted-warps) are in use, the  `huskhomes.command.warp.(warp_name)` permission node will also be required to be able to view and use warps.
 
 &ddagger; &mdash; Requires `return_by_death` to be enabled in [`config.yml`](config-files).
 
 ### Command Aliases
-
 The following commands have aliases that can also be used for convenience:
 
 | Command      | Aliases                      |
@@ -459,8 +440,7 @@ The following commands have aliases that can also be used for convenience:
 
 ## Disabling commands
 
-If you'd like to disable a command, add it to the `disabled_commands` section of your config file as detailed below and
-the command will not be registered.
+If you'd like to disable a command, add it to the `disabled_commands` section of your config file as detailed below and the command will not be registered.
 
 <details>
 <summary>Disabling a command in config.yml</summary>
@@ -473,26 +453,19 @@ disabled_commands: [ '/rtp' ]
 </details>
 
 ## Home limits
-
-You can modify the maximum number of homes, the allotment of free homes and the number of public homes a user can set
-through permission nodes.
+You can modify the maximum number of homes, the allotment of free homes and the number of public homes a user can set through permission nodes.
 
 * `huskhomes.max_homes.<amount>` — Determines the max number of homes a user can set
-* `huskhomes.free_homes.<amount>` — Determines the allotment of homes the user can set for free, before they have to
-  pay&dagger;
+* `huskhomes.free_homes.<amount>` — Determines the allotment of homes the user can set for free, before they have to pay&dagger;
 * `huskhomes.max_public_homes.<amount>` — Determines the maximum number of homes a user can make public
 
 &dagger;Only effective on servers that make use of the economy hook.
 
-If users have multiple permission nodes (i.e. from being in multiple permission groups), HuskHomes will accept the
-highest. If you prefer that the nodes _stack_, you can set the `stack_permission_limits` setting in the plugin config
-file to `true` (under `general`).
+If users have multiple permission nodes (i.e. from being in multiple permission groups), HuskHomes will accept the highest. If you prefer that the nodes _stack_, you can set the `stack_permission_limits` setting in the plugin config file to `true` (under `general`).
 
-Note that these permission-set values override the values set in the plugin config (`max_homes`, `max_public_homes`
-under `general` and `free_homes` under `economy`).
+Note that these permission-set values override the values set in the plugin config (`max_homes`, `max_public_homes` under `general` and `free_homes` under `economy`).
 
 ## Teleport warmup times
-
 You can change the teleport warmup time based on a permission node:
 
 * `huskhomes.teleport_warmup.<seconds>` — Determines how long this player has to wait before teleporting.
@@ -509,5 +482,4 @@ These permissions let you bypass teleportation warmup checks, cooldown, and econ
 | Bypass [cooldown checks](cooldowns)        | `huskhomes.bypass_cooldowns`       | Not set |
 | Bypass [economy checks](economy-hook)      | `huskhomes.bypass_economy_checks`  | Not set |
 
-&dagger;This is not effective when the teleport warmup time is set to `<= 0` in the config file. This permission also
-bypasses the numerical teleport warmup time permission detailed above.
+&dagger;This is not effective when the teleport warmup time is set to `<= 0` in the config file. This permission also bypasses the numerical teleport warmup time permission detailed above.


### PR DESCRIPTION
This PR improves the functionality and flexibility of the /rtp command by adding support for optional world and server arguments.

new config:
```yaml
rtp:
  cross_server: true
  random_target_servers:
    survival_server: ["world", "world_nether", "world_end"]
```

Behavior

-  (/rtp):

Behavior: The command will search for the player’s current world on all defined servers in `random_target_servers`. If the world exists on multiple servers, one is chosen randomly. If not just return not exist.

- (/rtp world_nether):

Behavior: Searches all `random_target_servers `to locate the specified world.

- (/rtp world_nether survival_server): 

Behavior: Directly teleports the player to `world_nether `on `survival_server` list of worlds.

- (/rtp survival_server):

Behavior: Attempts to teleport the player to their current world on `survival_server`.


My code style might be weird, so let me know if you’d like any changes. I love the cross-server plugin!