### PR TITLE
Handle death event update async

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
+++ b/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
@@ -219,10 +219,13 @@ public abstract class EventListener {
      * @param onlineUser the {@link OnlineUser} who died
      */
     protected final void handlePlayerDeath(@NotNull OnlineUser onlineUser) {
-        if (plugin.getSettings().getGeneral().getBackCommand().isReturnByDeath() && plugin.getCommand(BackCommand.class)
-                .map(Command::getPermission).map(onlineUser::hasPermission).orElse(false)) {
-            plugin.getDatabase().setLastPosition(onlineUser, onlineUser.getPosition());
-        }
+        final Position lastPosition = onlineUser.getPosition();
+        plugin.runAsync(() -> {
+            if (plugin.getSettings().getGeneral().getBackCommand().isReturnByDeath() && plugin.getCommand(BackCommand.class)
+                    .map(Command::getPermission).map(onlineUser::hasPermission).orElse(false)) {
+                plugin.getDatabase().setLastPosition(onlineUser, lastPosition);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
This pull request updates database asynchronously on player death, avoid lag spike when doing database IO at server thread.

### Changes

- Run database update asynchronously in EventListener, capture position before async task is running.

Screenshot below shows this call is pretty expensive in servers.
![spark](https://github.com/user-attachments/assets/24b18d41-1be4-4f97-b445-dd82fd128085)
