### PR TITLE
Fix save_on_teleport_event does not work

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
+++ b/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
@@ -287,18 +287,18 @@ public abstract class EventListener {
 
     /**
      * Handle when a player teleports.
+     * When save_on_teleport_event in config is true and the world can be return, set user's last position.
      *
      * @param onlineUser     the {@link OnlineUser} who teleported
      * @param sourcePosition the source {@link Position} they came from
      */
     protected final void handlePlayerTeleport(@NotNull OnlineUser onlineUser, @NotNull Position sourcePosition) {
         final Settings.GeneralSettings.BackCommandSettings back = plugin.getSettings().getGeneral().getBackCommand();
-        if (!back.isSaveOnTeleportEvent() || back.canReturnToWorld(sourcePosition.getWorld())) {
-            return;
-        }
-
+        if (back.isSaveOnTeleportEvent() && back.canReturnToWorld(sourcePosition.getWorld())) {
         // Set the player's last position
         plugin.runAsync(() -> plugin.getDatabase().setLastPosition(onlineUser, sourcePosition));
+        }
+
     }
 
     /**


### PR DESCRIPTION
The guard function of `(!back.isSaveOnTeleportEvent() || back.canReturnToWorld(sourcePosition.getWorld()))` logic looks strange. It means that when the setting is enable or the can be return, then setLastPosition will not be trigger.

This changes make sure save_on_teleport_event and can return to world both true then trigger the setLastPosition.

Tested in purpur-1.21.4-2408 release 4.9.5 cannot save vanilla TP for /back , with this commit it works.

Solve #813 