### PR TITLE
Fix for the send teleport request event

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/command/TpRequestCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/TpRequestCommand.java
@@ -72,17 +72,18 @@ public class TpRequestCommand extends InGameCommand implements UserListTabComple
         }
 
         try {
-            manager.sendTeleportRequest(onlineUser, target, requestType);
+            manager.sendTeleportRequest(onlineUser, target, requestType, () -> handleSuccessfulRequest(onlineUser, target));
         } catch (IllegalArgumentException e) {
             plugin.getLocales().getLocale("error_player_not_found", target)
                     .ifPresent(onlineUser::sendMessage);
-            return;
         }
+    }
 
+    private void handleSuccessfulRequest(@NotNull OnlineUser onlineUser, @NotNull String target) {
         plugin.performTransaction(onlineUser, TransactionResolver.Action.SEND_TELEPORT_REQUEST);
         plugin.getLocales()
                 .getLocale((requestType == TeleportRequest.Type.TPA ? "tpa" : "tpahere")
-                           + "_request_sent", target)
+                        + "_request_sent", target)
                 .ifPresent(onlineUser::sendMessage);
     }
 

--- a/common/src/main/java/net/william278/huskhomes/manager/RequestsManager.java
+++ b/common/src/main/java/net/william278/huskhomes/manager/RequestsManager.java
@@ -152,6 +152,7 @@ public class RequestsManager {
         final long expiry = Instant.now().getEpochSecond()
                 + plugin.getSettings().getGeneral().getTeleportRequestExpiryTime();
         final TeleportRequest request = new TeleportRequest(requester, type, expiry);
+        request.setRecipientName(targetUser);
 
         // Lookup the user locally first. If there's a username match globally, perform an exact local check
         final Optional<OnlineUser> localTarget = plugin.isUserOnlineGlobally(targetUser)
@@ -173,7 +174,6 @@ public class RequestsManager {
 
         // If the player couldn't be found locally, send the request cross-server
         if (plugin.getSettings().getCrossServer().isEnabled()) {
-            request.setRecipientName(targetUser);
             plugin.fireEvent(
                     plugin.getSendTeleportRequestEvent(requester, request),
                     (event -> {


### PR DESCRIPTION
While listening to the SendTeleportRequestEvent for a plugin of mine that integrates with HuskHomes, I noticed that the recipientName is always null (for local lookup). As a result, I can't obtain a reference to the target player.

Additionally, the messages with keys tpa_request_sent / tpahere_request_sent are always sent, even if the event is cancelled. This also affects the economy system, as the transaction is executed even when the event is cancelled.

This PR aims to fix both issues.

I handled the message feedback (tpa_request_sent / tpahere_request_sent) via a callback to keep control at the Command level. However, let me know if you’d prefer to remove the callback and move the logic into the RequestManager class instead.

I didn't have much time to check if similar issues exist in other events—my focus was solely on this one. Apologies for that