### PR TITLE
Add more config options for Redis

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/config/Settings.java
+++ b/common/src/main/java/net/william278/huskhomes/config/Settings.java
@@ -284,6 +284,7 @@ public final class Settings {
         public static class RedisSettings {
             private String host = "localhost";
             private int port = 6379;
+            @Comment("Only change this if you know what you are doing. The default value is 0.")
             private int database = 0;
             @Comment("Password for your Redis server. Leave blank if you're not using a password.")
             private String password = "";

--- a/common/src/main/java/net/william278/huskhomes/config/Settings.java
+++ b/common/src/main/java/net/william278/huskhomes/config/Settings.java
@@ -31,6 +31,7 @@ import net.william278.huskhomes.network.Broker;
 import net.william278.huskhomes.position.World;
 import net.william278.huskhomes.util.TransactionResolver;
 import org.jetbrains.annotations.NotNull;
+import redis.clients.jedis.Protocol;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -283,8 +284,11 @@ public final class Settings {
         public static class RedisSettings {
             private String host = "localhost";
             private int port = 6379;
+            private int database = 0;
             @Comment("Password for your Redis server. Leave blank if you're not using a password.")
             private String password = "";
+            @Comment("Timeout for connecting to the Redis server (in milliseconds)")
+            private int timeout = Protocol.DEFAULT_TIMEOUT;
             private boolean useSsl = false;
 
             @Comment({"Settings for if you're using Redis Sentinels.",

--- a/common/src/main/java/net/william278/huskhomes/network/RedisBroker.java
+++ b/common/src/main/java/net/william278/huskhomes/network/RedisBroker.java
@@ -72,7 +72,7 @@ public class RedisBroker extends PluginMessageBroker {
     @NotNull
     private static Pool<Jedis> getJedisPool(@NotNull RedisSettings settings) {
         // Get the Redis connection settings
-        String password = settings.getPassword();
+        final String password = settings.getPassword();
         final String host = settings.getHost();
         final int port = settings.getPort();
         final int database = settings.getDatabase();
@@ -102,10 +102,15 @@ public class RedisBroker extends PluginMessageBroker {
         }
 
         // Otherwise, use the standard Jedis pool
-        if (password.isEmpty()) {
-            password = null;
-        }
-        return new JedisPool(config, host, port, timeout, password, database, useSSL);
+        return new JedisPool(
+                config,
+                host,
+                port,
+                timeout,
+                password.isEmpty() ? null : password,
+                database,
+                useSSL
+        );
     }
 
     @Override


### PR DESCRIPTION
I noticed that HuskHomes lacks some configuration options for Redis that I think could be useful.

This PR adds a couple of options to the configuration:
- the database (set to 0 by default)
- the connection timeout (set to 2000ms, which is the default value set by Redis)